### PR TITLE
Compatibility with firefox

### DIFF
--- a/extension/devtool.js
+++ b/extension/devtool.js
@@ -5,7 +5,11 @@ var moreTimes = 4 - (timesExtensionHasLoaded - 1);
 if (moreTimes >= 0) {
     var message = "Immutable Object Formatter: Make sure to check 'Enable custom formatters' in the DevTools settings.";
     message += " (This message will show " + moreTimes + " more time" + (moreTimes === 1 ? "" :"s") + ".)";
-    chrome.devtools.inspectedWindow.eval( 
+
+    // browser is for firefox, else fallback to chrome
+    const target = browser ?? chrome;
+
+    target.devtools.inspectedWindow.eval( 
       'console.log("' + message +  '")'
       , function(){})
 }


### PR DESCRIPTION
As said in https://github.com/mattzeunert/immutable-object-formatter-extension/issues/36, firefox compatibility is nearly built-in, we just need to check the browser / chrome variable.

This is the only change I made to make FF extension work in dev with web-ext on the test page.

It has already been released in Firefox addons : https://addons.mozilla.org/fr/firefox/addon/immutable-js-console-formatter/